### PR TITLE
Add clean action to github actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,5 +36,5 @@ jobs:
           yarn workspaces run test
 
       - name: Clean All
-	run: |
-	  yarn workspaces run clean
+      	run: |
+      	  yarn workspaces run clean


### PR DESCRIPTION
This will fail builds now if they fail to run their clean action. This way we can ensure all packages implement a clean action in the future since its defined in the top level package.json as an NPM task.