### PR TITLE
Remove inputcontrols config at instantiation

### DIFF
--- a/packages/jv-input-controls/src/InputControls.tsx
+++ b/packages/jv-input-controls/src/InputControls.tsx
@@ -1,26 +1,16 @@
-import { createRoot } from "react-dom/client";
 import { StylesProvider as JVStylesProvider } from "@jaspersoft/jv-ui-components/material-ui/styles/StylesProvider";
-import {
-  BaseInputControlProps,
-  InputControlCollection,
-} from "./controls/BaseInputControl";
+import { createRoot } from "react-dom/client";
+import { InputControlCollection } from "./controls/BaseInputControl";
 import { BoolICType } from "./controls/BooleanInputControl";
 import { DatePickerICType } from "./controls/DatePickerInputControl";
 import { DateICType } from "./controls/DatePickerTextFieldInputControl";
-import { DateTimeICType } from "./controls/DateTimePickerTextFieldInputControl";
 import { DateTimePickerICType } from "./controls/DateTimePickerInputControl";
+import { DateTimeICType } from "./controls/DateTimePickerTextFieldInputControl";
 import { NumberICType } from "./controls/SingleValueNumberInputControl";
 import { TextFieldICType } from "./controls/SingleValueTextInputControl";
 import { TimePickerICType } from "./controls/TimePickerInputControl";
 import { TimeICType } from "./controls/TimePickerTextFieldInputControl";
 import BasePanel from "./panels/BasePanel";
-
-export interface InputControlConfig {
-  hostname?: string;
-  username: string;
-  password: string;
-  tenant: string;
-}
 
 export interface InputControlUserConfig {
   bool?: {
@@ -56,28 +46,12 @@ export interface InputControlPanelConfig {
   };
 }
 
-const defaultInputControlConfig: InputControlConfig = {
-  username: "joeuser",
-  password: "joeuser",
-  tenant: "organization_1",
-};
-
 export class InputControls {
   private viz: any;
-  private _config: InputControlConfig;
   protected controlStructure: object = {};
 
-  get config(): InputControlConfig {
-    return this._config;
-  }
-
-  set config(value: InputControlConfig) {
-    this._config = value;
-  }
-
-  constructor(vizjs: any, config?: InputControlConfig) {
+  constructor(vizjs: any) {
     this.viz = vizjs;
-    this._config = config || defaultInputControlConfig;
   }
 
   public fillControlStructure = (

--- a/packages/jv-input-controls/test/InputControls.test.ts
+++ b/packages/jv-input-controls/test/InputControls.test.ts
@@ -1,17 +1,9 @@
-import { InputControls } from '../src/InputControls';
+import { InputControls } from "../src/InputControls";
 
 describe("InputControls plugin", () => {
-
   it("should allow instantiation, and do so with default config settings", () => {
     let ic = new InputControls({});
     expect(ic).toBeDefined();
     expect(ic.getControls()).toEqual({});
-    expect(ic.config.username).toBe('joeuser');
   });
-
-  it("should configure when given configuration", () => {
-    let ic = new InputControls({}, { username: 'bobuser', password: 'bobuser', tenant: 'org' });
-    expect(ic.config.username).toBe('bobuser');
-  });
-
 });


### PR DESCRIPTION
This removes an unused config setting that was at instantiation of input controls and referenced in docs.

Removed from docs too in https://github.com/Jaspersoft/js-visualize-components-samples/pull/3