### PR TITLE
fix(jv-input-controls): fix readOnly attribute for boolean input control

### DIFF
--- a/packages/jv-input-controls/src/controls/BooleanInputControl.tsx
+++ b/packages/jv-input-controls/src/controls/BooleanInputControl.tsx
@@ -39,6 +39,7 @@ export function BooleanInputControl(
         containerClassName={`${controlClasses.join(" ")} jv-mInputLarge`}
         inline={true}
         labelPlacement="end"
+        disabled={props.readOnly}
       />
     );
   } else {
@@ -51,6 +52,7 @@ export function BooleanInputControl(
             checked: !!liveState.value,
           }}
           className={controlClasses.join(" ")}
+          disabled={props.readOnly}
         />
       </JVCheckboxGroup>
     );

--- a/packages/jv-input-controls/test/controls/BooleanInputControl.test.tsx
+++ b/packages/jv-input-controls/test/controls/BooleanInputControl.test.tsx
@@ -39,9 +39,15 @@ describe("BooleanInputControl tests", () => {
     expect((switchElement[0] as any).checked).not.toBeTruthy();
   });
 
-  it("should be chekced when state.value === true", () => {
+  it("should be checked when state.value === true", () => {
     render(getBoolIC({ state: { value: "true" } }));
     const checkboxElement = document.querySelectorAll('input[type="checkbox"]');
     expect((checkboxElement[0] as any).checked).toBeTruthy();
+  });
+
+  it("should be disabled when readOnly is true", () => {
+    render(getBoolIC({ readOnly: true }));
+    const checkboxElement = document.querySelector('input[type="checkbox"]');
+    expect(checkboxElement).toHaveProperty("disabled", true);
   });
 });


### PR DESCRIPTION
readOnly attribute is fixed for boolean input control

![image](https://github.com/user-attachments/assets/c5214cf9-c23c-482a-80c8-f84fe2ad234f)
