### PR TITLE
fix(jv-input-controls): fix min date when is not provided by server

### DIFF
--- a/packages/jv-input-controls/src/utils/DateInputControlUtils.ts
+++ b/packages/jv-input-controls/src/utils/DateInputControlUtils.ts
@@ -138,13 +138,17 @@ export const verifyDateLimit = ({
   isVerifyingMin,
 }: {
   dataType: InputControlDataType | undefined;
-  maxOrMinDateAsString: string | null;
+  maxOrMinDateAsString: string | null | undefined;
   dateAsString: string;
   isVerifyingMin: boolean;
 }): { helperText: string; isError: boolean } => {
   let helperText = "";
   let isError = false;
-  if (dataType === undefined || maxOrMinDateAsString === null) {
+  if (
+    dataType === undefined ||
+    maxOrMinDateAsString === null ||
+    maxOrMinDateAsString === undefined
+  ) {
     return { helperText, isError };
   }
   // verify the number is under the limits of the data type


### PR DESCRIPTION
while working on the documentation for every input control, I found this issue
this commit is intended to fix the validation for the min date in case it is not provided by the server