### PR TITLE
fix(jv-ui-components): fix styles for components in storybook

### DIFF
--- a/packages/jv-ui-components/.storybook/preview.tsx
+++ b/packages/jv-ui-components/.storybook/preview.tsx
@@ -1,6 +1,5 @@
-import "@jaspersoft/jv-ui-components/material-ui/styles/JVMuiClassNameSetup";
 import "./styles/storybook-jv-ui.scss";
-import { JVStylesProvider } from "@jaspersoft/jv-ui-components";
+import { JVStylesProvider } from "../material-ui";
 import type { Preview } from "@storybook/react";
 
 const preview: Preview = {

--- a/packages/jv-ui-components/stories/material-ui/accordion/AccordionComponents.stories.tsx
+++ b/packages/jv-ui-components/stories/material-ui/accordion/AccordionComponents.stories.tsx
@@ -7,7 +7,7 @@ import {
   JVAccordionDetails,
   JVAccordionFull,
   JVAccordionSummary,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import { Typography } from "@mui/material";
 
 /*----------------------------

--- a/packages/jv-ui-components/stories/material-ui/autocomplete/AutoCompleteInput.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/autocomplete/AutoCompleteInput.stories.jsx
@@ -3,7 +3,7 @@ import {
   JVIcon,
   JVIconButton,
   JVTextField,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import {
   Checkbox,
   FormControlLabel,

--- a/packages/jv-ui-components/stories/material-ui/autocomplete/AutoCompleteInputComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/autocomplete/AutoCompleteInputComponents.stories.jsx
@@ -8,7 +8,7 @@ import {
   JVPaper,
   JVPopper,
   JVTextField,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import "../css/demoPages.css";
 import "./autoCompleteInput.css";
 import { useRef, useState } from "react";

--- a/packages/jv-ui-components/stories/material-ui/badge/BadgeComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/badge/BadgeComponents.stories.jsx
@@ -1,6 +1,6 @@
 import "../css/demoPages.css";
 import "./badge.css";
-import { JVBadge, JVTypography } from "@jaspersoft/jv-ui-components";
+import { JVBadge, JVTypography } from "../../../material-ui";
 import MailIcon from "@mui/icons-material/Mail";
 
 /*------------------------------

--- a/packages/jv-ui-components/stories/material-ui/button-group/ButtonGroupComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/button-group/ButtonGroupComponents.stories.jsx
@@ -2,7 +2,7 @@ import {
   JVButtonGroup,
   JVIconButton,
   JVLabeledButtonGroup,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import "./buttonGroup.css";
 
 /*----------------------------------

--- a/packages/jv-ui-components/stories/material-ui/button/ButtonComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/button/ButtonComponents.stories.jsx
@@ -7,7 +7,7 @@ import {
   JVIcon,
   JVIconButton,
   JVToolbar,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 
 /* --------------------------------------------------------------
  *  TABLE OF CONTENTS

--- a/packages/jv-ui-components/stories/material-ui/calendar/Calendar.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/calendar/Calendar.stories.jsx
@@ -3,7 +3,7 @@ import {
   JVPopper,
   JVSelectItem,
   JVTextField,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import {
   Button,
   List,

--- a/packages/jv-ui-components/stories/material-ui/calendar/CalendarComponent.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/calendar/CalendarComponent.stories.jsx
@@ -9,11 +9,12 @@ import {
   JVSelectItem,
   JVTextField,
   JVTypography,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import { useRef, useState } from "react";
 import "../css/demoPages.css";
 import "./calendar.css";
-
+import "../css/demoPages.css";
+import "./calendar.css";
 /*----------------------------
  *  TABLE OF CONTENTS
  *

--- a/packages/jv-ui-components/stories/material-ui/dialog/DialogComponent.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/dialog/DialogComponent.stories.jsx
@@ -5,7 +5,7 @@ import {
   JVPaper,
   JVTextField,
   JVTypography,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import { DialogContentText, Typography } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
 import Draggable from "react-draggable";

--- a/packages/jv-ui-components/stories/material-ui/divider/DividerComponent.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/divider/DividerComponent.stories.jsx
@@ -1,9 +1,5 @@
 import "../inputs/inputs.css";
-import {
-  JVDivider,
-  JVIconButton,
-  JVTextField,
-} from "@jaspersoft/jv-ui-components";
+import { JVDivider, JVIconButton, JVTextField } from "../../../material-ui";
 
 /*----------------------------
  *  TABLE OF CONTENTS

--- a/packages/jv-ui-components/stories/material-ui/drawer/DrawerComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/drawer/DrawerComponents.stories.jsx
@@ -1,4 +1,4 @@
-import { JVButton, JVDrawer, JVTypography } from "@jaspersoft/jv-ui-components";
+import { JVButton, JVDrawer, JVTypography } from "../../../material-ui";
 /*  ------------------------------  */
 /*    Table of Contents             */
 /*                                  */

--- a/packages/jv-ui-components/stories/material-ui/icon/IconComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/icon/IconComponents.stories.jsx
@@ -1,5 +1,5 @@
 import "./icon.css";
-import { JVIcon } from "@jaspersoft/jv-ui-components";
+import { JVIcon } from "../../../material-ui";
 
 /*----------------------------
  *  TABLE OF CONTENTS

--- a/packages/jv-ui-components/stories/material-ui/inputs/Inputs.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/inputs/Inputs.stories.jsx
@@ -1,8 +1,4 @@
-import {
-  JVIcon,
-  JVIconButton,
-  JVTextField,
-} from "@jaspersoft/jv-ui-components";
+import { JVIcon, JVIconButton, JVTextField } from "../../../material-ui";
 import {
   Button,
   Checkbox,
@@ -3001,7 +2997,7 @@ inputSelect.storyName = "Select";
 /*  07. SWITCH    */
 /* -------------- */
 export const inputSwitch = () => {
-  const [state, setState] = React.useState({
+  const [state, setState] = useState({
     checkedA: true,
     checkedB: true,
     checkedC: true,

--- a/packages/jv-ui-components/stories/material-ui/inputs/InputsComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/inputs/InputsComponents.stories.jsx
@@ -15,7 +15,7 @@ import {
   JVSwitch,
   JVTextField,
   JVTypography,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 // this grid component is used for proper alignment of all variations of input in storybook. That's why directly imported from the
 // material-ui.
 import { Grid } from "@mui/material";

--- a/packages/jv-ui-components/stories/material-ui/instructor/InstructorComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/instructor/InstructorComponents.stories.jsx
@@ -1,6 +1,6 @@
 import "../inputs/inputs.css";
 import "./instructor.css";
-import { JVInstructor, JVTextField } from "@jaspersoft/jv-ui-components";
+import { JVInstructor, JVTextField } from "../../../material-ui";
 
 /*----------------------------
  *  TABLE OF CONTENTS

--- a/packages/jv-ui-components/stories/material-ui/message/MessageComponent.stories.tsx
+++ b/packages/jv-ui-components/stories/material-ui/message/MessageComponent.stories.tsx
@@ -9,7 +9,7 @@ import {
   JVIcon,
   JVIconButton,
   JVButton,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 
 /*----------------------------
  *  TABLE OF CONTENTS

--- a/packages/jv-ui-components/stories/material-ui/panel/PanelComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/panel/PanelComponents.stories.jsx
@@ -8,7 +8,7 @@ import {
   JVIconButton,
   JVSubPanel,
   JVFlushPanel,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import { Snackbar } from "@mui/material";
 
 /*----------------------------

--- a/packages/jv-ui-components/stories/material-ui/progress/ProgressComponent.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/progress/ProgressComponent.stories.jsx
@@ -1,7 +1,4 @@
-import {
-  JVCircularProgress,
-  JVLinearProgress,
-} from "@jaspersoft/jv-ui-components";
+import { JVCircularProgress, JVLinearProgress } from "../../../material-ui";
 import { useEffect, useState } from "react";
 import "../css/demoPages.css";
 import "./progress.css";

--- a/packages/jv-ui-components/stories/material-ui/stepper/Stepper.stories.tsx
+++ b/packages/jv-ui-components/stories/material-ui/stepper/Stepper.stories.tsx
@@ -1,4 +1,4 @@
-import { JVIcon } from "@jaspersoft/jv-ui-components";
+import { JVIcon } from "../../../material-ui";
 import {
   Button,
   Checkbox,

--- a/packages/jv-ui-components/stories/material-ui/stepper/StepperComponent.stories.tsx
+++ b/packages/jv-ui-components/stories/material-ui/stepper/StepperComponent.stories.tsx
@@ -13,7 +13,7 @@ import {
   JVTabs,
   JVTextField,
   JVTypography,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 import { ChangeEvent, useState } from "react";
 import "./stepper.css";
 import {

--- a/packages/jv-ui-components/stories/material-ui/tabs/TabsComponent.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/tabs/TabsComponent.stories.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import "../css/demoPages.css";
 import "./tabs.css";
-import { JVTabs, JVTab } from "@jaspersoft/jv-ui-components";
+import { JVTabs, JVTab } from "../../../material-ui";
 
 /*------------------------------
  *  TABLE OF CONTENTS

--- a/packages/jv-ui-components/stories/material-ui/toolbar/Toolbar.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/toolbar/Toolbar.stories.jsx
@@ -1,4 +1,4 @@
-import { JVIcon, JVInputAdornment } from "@jaspersoft/jv-ui-components";
+import { JVIcon, JVInputAdornment } from "../../../material-ui";
 import {
   Divider,
   IconButton,

--- a/packages/jv-ui-components/stories/material-ui/toolbar/ToolbarComponents.stories.jsx
+++ b/packages/jv-ui-components/stories/material-ui/toolbar/ToolbarComponents.stories.jsx
@@ -9,7 +9,7 @@ import {
   JVTypography,
   JVInputAdornment,
   JVIcon,
-} from "@jaspersoft/jv-ui-components";
+} from "../../../material-ui";
 
 /* ------------------------------
  *  TABLE OF CONTENTS

--- a/packages/jv-ui-components/stories/material-ui/typography/TypographyComponents.stories.tsx
+++ b/packages/jv-ui-components/stories/material-ui/typography/TypographyComponents.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "./typography.css";
-import { JVTypography, JVLink } from "@jaspersoft/jv-ui-components";
+import { JVTypography, JVLink } from "../../../material-ui";
 
 /*------------------------------
  *  TABLE OF CONTENTS


### PR DESCRIPTION
after the update on how the styles are loaded when the libraries were published in npm, the storybook had to be updated as well to use the local components because the "preview.tsx" file already loads the styles, so no need to use the compiled components

![image](https://github.com/user-attachments/assets/3e612c52-0c07-49a1-8811-6bcb0d9be650)

![image](https://github.com/user-attachments/assets/a8bf6fee-9dd9-4f30-a327-329cd22d84fd)


![image](https://github.com/user-attachments/assets/8d274eac-9774-4d61-8c8e-dbe7361985a1)
