### PR TITLE
feature(jv-tools): enhance useVisualize hook to accept error callback

### DIFF
--- a/packages/demo-input-controls/src/App.tsx
+++ b/packages/demo-input-controls/src/App.tsx
@@ -10,12 +10,13 @@ import {
   Authentication,
   InputControlProperties,
   useVisualize,
+  VisualizeGenericError,
 } from "@jaspersoft/jv-tools";
 import { useEffect, useState } from "react";
 import ReportPanel from "./report/ReportPanel.tsx";
 
 const myAuth: Authentication = {
-  name: "joeuser",
+  name: "joeuser2",
   password: "joeuser",
   organization: "organization_1",
   locale: "en_US",
@@ -27,8 +28,12 @@ const singleSelectReportUri = "/public/Samples/Reports/9g.CustomerDetailReport";
 const visualizeUrl =
   "https://mobiledemo.jaspersoft.com/jasperserver-pro/client/visualize.js";
 
+const errorCallback = (errorCaught: Error | VisualizeGenericError) => {
+  console.log("check the error! ", errorCaught);
+};
+
 function App() {
-  const vContainer = useVisualize(visualizeUrl, myAuth);
+  const vContainer = useVisualize(visualizeUrl, myAuth, { errorCallback });
   const [controlBuffer, setControlBuffer] =
     useState<InputControlProperties[]>();
   const [vReport, setVReport] = useState<any>();

--- a/packages/demo-input-controls/src/App.tsx
+++ b/packages/demo-input-controls/src/App.tsx
@@ -28,7 +28,7 @@ const singleSelectReportUri = "/public/Samples/Reports/9g.CustomerDetailReport";
 const visualizeUrl =
   "https://mobiledemo.jaspersoft.com/jasperserver-pro/client/visualize.js";
 
-const errorCallback = (errorCaught: Error | VisualizeGenericError) => {
+const errorCallback = (errorCaught: Error | VisualizeGenericError | string) => {
   console.log("check the error! ", errorCaught);
 };
 

--- a/packages/demo-input-controls/src/App.tsx
+++ b/packages/demo-input-controls/src/App.tsx
@@ -16,7 +16,7 @@ import { useEffect, useState } from "react";
 import ReportPanel from "./report/ReportPanel.tsx";
 
 const myAuth: Authentication = {
-  name: "joeuser2",
+  name: "joeuser",
   password: "joeuser",
   organization: "organization_1",
   locale: "en_US",

--- a/packages/jv-tools/index.ts
+++ b/packages/jv-tools/index.ts
@@ -1,5 +1,6 @@
 import { InputControlProperties } from "./src/input-controls";
 export * from "./src/input-controls";
+export type { useVisualizeConfig } from "./src/visualize/hooks/useVisualize.types";
 
 export type Authentication = {
   url?: string;

--- a/packages/jv-tools/src/visualize/hooks/useVisualize.ts
+++ b/packages/jv-tools/src/visualize/hooks/useVisualize.ts
@@ -5,12 +5,12 @@ import {
   VisualizeFactory,
   Authentication,
   useVisualizeConfig,
+  VisualizeGenericError,
 } from "../../..";
-import { VisualizeGenericError } from "../../../index";
 
 const logOrTriggerError = (
   config: useVisualizeConfig | undefined,
-  error: Error | VisualizeGenericError,
+  error: Error | VisualizeGenericError | string,
 ) => {
   if (config?.errorCallback) {
     config?.errorCallback(error);
@@ -38,10 +38,11 @@ const useVisualize = (
           (v: VisualizeClient) => {
             setVContainer({ v });
           },
-          (e: Error | VisualizeGenericError) => logOrTriggerError(config, e),
+          (e: Error | VisualizeGenericError | string) =>
+            logOrTriggerError(config, e),
         );
       })
-      .catch((error: Error | VisualizeGenericError) =>
+      .catch((error: Error | VisualizeGenericError | string) =>
         logOrTriggerError(config, error),
       );
   }, [uri]);

--- a/packages/jv-tools/src/visualize/hooks/useVisualize.ts
+++ b/packages/jv-tools/src/visualize/hooks/useVisualize.ts
@@ -4,9 +4,26 @@ import {
   visualizejsLoader,
   VisualizeFactory,
   Authentication,
+  useVisualizeConfig,
 } from "../../..";
+import { VisualizeGenericError } from "../../../index";
 
-const useVisualize = (uri: string, auth?: Authentication) => {
+const logOrTriggerError = (
+  config: useVisualizeConfig | undefined,
+  error: Error | VisualizeGenericError,
+) => {
+  if (config?.errorCallback) {
+    config?.errorCallback(error);
+  } else {
+    console.error(String(error));
+  }
+};
+
+const useVisualize = (
+  uri: string,
+  auth: Authentication,
+  config?: useVisualizeConfig,
+) => {
   const [vContainer, setVContainer] = useState<{ v: VisualizeClient } | null>(
     null,
   );
@@ -21,14 +38,12 @@ const useVisualize = (uri: string, auth?: Authentication) => {
           (v: VisualizeClient) => {
             setVContainer({ v });
           },
-          (e: any) => {
-            console.error(String(e));
-          },
+          (e: Error | VisualizeGenericError) => logOrTriggerError(config, e),
         );
       })
-      .catch((error: Error) => {
-        console.error("Error loading visualize.js: ", error);
-      });
+      .catch((error: Error | VisualizeGenericError) =>
+        logOrTriggerError(config, error),
+      );
   }, [uri]);
 
   return vContainer;

--- a/packages/jv-tools/src/visualize/hooks/useVisualize.types.ts
+++ b/packages/jv-tools/src/visualize/hooks/useVisualize.types.ts
@@ -4,8 +4,8 @@
  * in the license file that is distributed with this file.
  */
 
-import { VisualizeGenericError } from "../../../index";
+import { VisualizeGenericError } from "../../..";
 
 export interface useVisualizeConfig {
-  errorCallback: (error: Error | VisualizeGenericError) => void;
+  errorCallback: (error: Error | VisualizeGenericError | string) => void;
 }

--- a/packages/jv-tools/src/visualize/hooks/useVisualize.types.ts
+++ b/packages/jv-tools/src/visualize/hooks/useVisualize.types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright © 2024. Cloud Software Group, Inc.
+ * This file is subject to the license terms contained
+ * in the license file that is distributed with this file.
+ */
+
+import { VisualizeGenericError } from "../../../index";
+
+export interface useVisualizeConfig {
+  errorCallback: (error: Error | VisualizeGenericError) => void;
+}


### PR DESCRIPTION
this pull request fixes #91
now, the developers will be able to provide an error callback to the useVisualize hook to handle errors 

see image attached: 
![image](https://github.com/user-attachments/assets/0c95a8b1-2fe2-476d-83f2-925fbcec8cbc)
